### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/goudy_bookletter_1911.css
+++ b/webfonts/goudy_bookletter_1911.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Goudy Bookletter 1911';
+  src: url('goudy_bookletter_1911-webfont.eot'),
   src: url('goudy_bookletter_1911-webfont.eot?#iefix') format('embedded-opentype'),
        url('goudy_bookletter_1911-webfont.woff') format('woff'),
        url('goudy_bookletter_1911-webfont.ttf')  format('truetype'),

--- a/webfonts/goudy_bookletter_1911.css
+++ b/webfonts/goudy_bookletter_1911.css
@@ -10,7 +10,7 @@
 */
 @font-face {
   font-family: 'Goudy Bookletter 1911';
-  src: url('goudy_bookletter_1911-webfont.eot'),
+  src: url('goudy_bookletter_1911-webfont.eot');
   src: url('goudy_bookletter_1911-webfont.eot?#iefix') format('embedded-opentype'),
        url('goudy_bookletter_1911-webfont.woff') format('woff'),
        url('goudy_bookletter_1911-webfont.ttf')  format('truetype'),

--- a/webfonts/goudy_bookletter_1911.css
+++ b/webfonts/goudy_bookletter_1911.css
@@ -1,0 +1,17 @@
+/*
+  'Goudy Bookletter 1911'
+  https://www.theleagueofmoveabletype.com/goudy-bookletter-1911
+
+  Copyright (c) 2009, Barry Schwartz <site-chieftain@crudfactory.com>,
+  with Reserved Font Name OFL "Goudy Bookletter 1911".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Goudy Bookletter 1911';
+  src: url('goudy_bookletter_1911-webfont.eot?#iefix') format('embedded-opentype'),
+       url('goudy_bookletter_1911-webfont.woff') format('woff'),
+       url('goudy_bookletter_1911-webfont.ttf')  format('truetype'),
+       url('goudy_bookletter_1911-webfont.svg#webfontiT6p4ac4') format('svg');
+}


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
