### PR TITLE
Improvements to readme: update links, add images, formatting

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,15 +1,18 @@
-![Goudy Bookletter 1911](https://github.com/theleagueof/goudy-bookletter-1911/raw/master/images/goudy-bookletter-1911-1.jpeg)
+![Goudy Bookletter 1911 specimen, shown at a range of sizes and colors](https://github.com/theleagueof/goudy-bookletter-1911/raw/master/images/goudy-bookletter-1911-1.jpeg)
 
 Goudy Bookletter 1911
 ========
-_by [Barry Schwartz](http://www.crudfactory.com)_
+_by [Barry Schwartz](http://crudfactory.com/font/show/gb1911)_
 
 Based on Frederic Goudy’s Kennerley Oldstyle.
 
-    Notes from Barry:
+Notes from Barry:
 
-    This font predates the League and is in the public domain.
-    
-    A few words on why I think Kennerley Oldstyle is beautiful: In making this font, I discovered that Kennerley fits together tightly and evenly with almost no kerning. Thus the following words from Monotype specimen books are just: “[W]hen composed into words the characters appear to lock into one another with a closeness common in early types, but not so often seen in later-day creations.” These are letters that take command of the space around them; notice, for instance, the bowed shapes of the v and w.
-    
-    Side note: One of the spec images includes public domain clipart from openclipart.org. Go visit! :)
+> This font predates the League and is in the public domain.
+>
+> A few words on why I think Kennerley Oldstyle is beautiful: In making this font, I discovered that Kennerley fits together tightly and evenly with almost no kerning. Thus the following words from Monotype specimen books are just: “[W]hen composed into words the characters appear to lock into one another with a closeness common in early types, but not so often seen in later-day creations.” These are letters that take command of the space around them; notice, for instance, the bowed shapes of the v and w.
+>
+> Side note: One of the spec images includes public domain clipart from [openclipart.org](https://openclipart.org). Go visit! :)
+
+![Goudy Bookletter 1911 specimen, shown as a cocktail recipe](https://github.com/theleagueof/goudy-bookletter-1911/raw/master/images/goudy-bookletter-1911-2.jpeg)
+![Goudy Bookletter 1911 specimen, showing numbers, symbols, and accents](https://github.com/theleagueof/goudy-bookletter-1911/raw/master/images/goudy-bookletter-1911-3.jpeg)


### PR DESCRIPTION
## Changes

- Format quote from Barry Schwartz as quote, to improve readability. The previous indentation caused GitHub's Markdown parser to present that text block as code, without line wrapping.
- Include all specimen images in README, to match https://www.theleagueofmoveabletype.com/goudy-bookletter-1911
- Add alt text to specimen images, for accessibility
- Change link for Barry Schwartz from homepage of Barry's site to the specific font page on Barry's site, because the new link includes Barry's dedication of the font.